### PR TITLE
Update test plugin to 1.3.0

### DIFF
--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -9,15 +9,20 @@ new LOG_FILE[] = "test_nextclient_api.log";
 // Uncomment this if you do not want to check the values of the sandbox CVars yourself
 #define AUTO_RESTORE_CVAR_VALUES
 
+// ncl_precache_model() for default, already exists on client models like default weapon models
 #define TEST_PRECACHE_AND_REPLACE_DEFAULT_MODELS
 
+// ncl_precache_sound() for default, already exists on client sounds like steps
 #define TEST_PRECACHE_AND_REPLACE_DEFAULT_SOUNDS
 
 // Test of replace default hud.txt and HUD sprites
+// ncl_precache_hudtxt() & ncl_precache_client_only()
 #define TEST_PRECACHE_AND_REPLACE_HUD
 
+// ncl_precache_model() for custom model
 #define TEST_PRECACHE_AND_REPLACE_CUSTOM_MODELS
 
+// ncl_precache_sound() for custom sound
 #define TEST_PRECACHE_AND_REPLACE_CUSTOM_SOUNDS
 
 new const HUD_SPRITE_KILL[] = "sprites/test_nextclient/hud_sprites/kill.spr"

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -71,7 +71,7 @@ public cmd_ncl_is_client_api_ready(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -88,7 +88,7 @@ public cmd_ncl_is_using_nextclient(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -119,7 +119,7 @@ public cmd_ncl_get_nextclient_version(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -140,7 +140,7 @@ public cmd_ncl_get_supported_features(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -243,7 +243,7 @@ public cmd_ncl_test_sandbox_cvars(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -304,7 +304,7 @@ public cmd_ncl_restore_cvars_values(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -330,7 +330,7 @@ public cmd_ncl_test_viewmodelfx_skin(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -359,7 +359,7 @@ public cmd_ncl_test_viewmodelfx_body(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -385,7 +385,7 @@ public cmd_ncl_test_viewmodelfx_render(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -410,7 +410,7 @@ public cmd_ncl_restore_viewmodelfx(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -438,7 +438,7 @@ public cmd_ncl_setfov(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -465,7 +465,7 @@ public cmd_ncl_hudsprite_set(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -614,7 +614,7 @@ public cmd_ncl_hudsprite_clear(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
@@ -804,15 +804,16 @@ public cmd_ncl_add_health(id) {
 
         if (id == 0) {
             log_amx("Player with userid #%i not found.", read_argv_int(1));
-            return;
+            return PLUGIN_HANDLED;
         }
     }
 
     if (!is_user_alive(id)) {
-        return;
+        return PLUGIN_HANDLED;
     }
 
     set_entvar(id, var_health, 99999999.0);
+    return PLUGIN_HANDLED;
 }
 
 /* <=== END OTHER FUNCS ===> */

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -48,8 +48,8 @@ public plugin_init() {
     register_concmd("ncl_test_viewmodelfx_render",   "cmd_ncl_test_viewmodelfx_render",  ADMIN_ALL);
     register_concmd("ncl_restore_viewmodelfx",       "cmd_ncl_restore_viewmodelfx",      ADMIN_ALL);
     register_concmd("ncl_setfov",                    "cmd_ncl_setfov",                   ADMIN_ALL);
-    register_concmd("ncl_hudsprite_set",             "cmd_ncl_hudsprite_set",            ADMIN_ALL);
-    register_concmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL);
+    register_concmd("ncl_hudsprite_set",             "cmd_ncl_hudsprite_set",            ADMIN_ALL); // ncl_send_hud_sprite(), ncl_send_hud_sprite_full_screen()
+    register_concmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL); // ncl_clear_hud_sprite()
 
     // Other cmds
     // For ncl_test_sandbox_cvars() if AUTO_RESTORE_CVAR_VALUES is disabled

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -26,6 +26,8 @@ new const HUD_SPRITE_BLACK_HOLE[] = "sprites/test_nextclient/hud_sprites/ef_blac
 public plugin_init() {
     register_plugin("Test NCL API", "1.3.0", "Nordic Warrior");
 
+    // Cmds for testing natives
+    // look at next_client_api.inc
     register_clcmd("ncl_is_client_api_ready",       "cmd_ncl_is_client_api_ready",      ADMIN_ALL);
     register_clcmd("ncl_is_using_nextclient",       "cmd_ncl_is_using_nextclient",      ADMIN_ALL);
     register_clcmd("ncl_get_nextclient_version",    "cmd_ncl_get_nextclient_version",   ADMIN_ALL);
@@ -39,6 +41,7 @@ public plugin_init() {
     register_clcmd("ncl_hudsprite_set",             "cmd_ncl_hudsprite_set",            ADMIN_ALL);
     register_clcmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL);
 
+    // Other cmds
     register_clcmd("ncl_restore_cvars_values", "cmd_ncl_restore_cvars_values", ADMIN_ALL);
 }
 

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -105,7 +105,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_CVARS_SANDBOX");
         bitsum &= ~NCL_FEATURE_CVARS_SANDBOX;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }
@@ -114,7 +114,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_VIEWMODEL_FX");
         bitsum &= ~NCL_FEATURE_VIEWMODEL_FX;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }
@@ -123,7 +123,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_PRIVATE_PRECACHE");
         bitsum &= ~NCL_FEATURE_PRIVATE_PRECACHE;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }
@@ -132,7 +132,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_VERIFICATION");
         bitsum &= ~NCL_FEATURE_VERIFICATION;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }
@@ -141,7 +141,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_HUD_SPRITE");
         bitsum &= ~NCL_FEATURE_HUD_SPRITE;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }
@@ -150,7 +150,7 @@ public cmd_ncl_get_supported_features(id) {
         add(result, charsmax(result), "NCL_FEATURE_HUD_SPRITE_RENDERMODE");
         bitsum &= ~NCL_FEATURE_HUD_SPRITE_RENDERMODE;
 
-        if (bitsum > 0) {
+        if (bitsum > any:0) {
             add(result, charsmax(result), " | ");
         }
     }

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -10,20 +10,20 @@ new LOG_FILE[] = "test_nextclient_api.log";
 #define AUTO_RESTORE_CVAR_VALUES
 
 // ncl_precache_model() for default, already exists on client models like default weapon models
-#define TEST_PRECACHE_AND_REPLACE_DEFAULT_MODELS
+// #define TEST_PRECACHE_AND_REPLACE_DEFAULT_MODELS
 
 // ncl_precache_sound() for default, already exists on client sounds like steps
-#define TEST_PRECACHE_AND_REPLACE_DEFAULT_SOUNDS
+// #define TEST_PRECACHE_AND_REPLACE_DEFAULT_SOUNDS
 
 // Test of replace default hud.txt and HUD sprites
 // ncl_precache_hudtxt() & ncl_precache_client_only()
-#define TEST_PRECACHE_AND_REPLACE_HUD
+// #define TEST_PRECACHE_AND_REPLACE_HUD
 
 // ncl_precache_model() for custom model
-#define TEST_PRECACHE_AND_REPLACE_CUSTOM_MODELS
+// #define TEST_PRECACHE_AND_REPLACE_CUSTOM_MODELS
 
 // ncl_precache_sound() for custom sound
-#define TEST_PRECACHE_AND_REPLACE_CUSTOM_SOUNDS
+// #define TEST_PRECACHE_AND_REPLACE_CUSTOM_SOUNDS
 
 new const HUD_SPRITE_KILL[] = "sprites/test_nextclient/hud_sprites/kill.spr"
 new const HUD_SPRITE_BLACK_HOLE[] = "sprites/test_nextclient/hud_sprites/ef_blackhole_loop.spr"

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -212,6 +212,15 @@ public cmd_ncl_get_supported_features(id) {
         }
     }
 
+    if (bitsum & NCL_FEATURE_DEATHMSG_WPN_ICON) {
+        add(result, charsmax(result), "NCL_FEATURE_DEATHMSG_WPN_ICON");
+        bitsum &= ~NCL_FEATURE_DEATHMSG_WPN_ICON;
+
+        if (bitsum > any:0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
     log_to_file(LOG_FILE, "Result: %s", result);
     return PLUGIN_HANDLED;
 }
@@ -820,6 +829,9 @@ public cmd_ncl_add_health(id) {
     if (!is_user_alive(id)) {
         return PLUGIN_HANDLED;
     }
+
+    log_to_file(LOG_FILE, "Testing HUD limit health for player: %n", id);
+    log_to_file(LOG_FILE, "* You should manually check a visual health in game.");
 
     set_entvar(id, var_health, 99999999.0);
     return PLUGIN_HANDLED;

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -1,4 +1,5 @@
 #include <amxmodx>
+#include <amxmisc>
 #include <fakemeta>
 #include <reapi>
 
@@ -33,24 +34,24 @@ public plugin_init() {
 
     // Cmds for testing natives
     // look at next_client_api.inc
-    register_clcmd("ncl_is_client_api_ready",       "cmd_ncl_is_client_api_ready",      ADMIN_ALL);
-    register_clcmd("ncl_is_using_nextclient",       "cmd_ncl_is_using_nextclient",      ADMIN_ALL);
-    register_clcmd("ncl_get_nextclient_version",    "cmd_ncl_get_nextclient_version",   ADMIN_ALL);
-    register_clcmd("ncl_get_supported_features",    "cmd_ncl_get_supported_features",   ADMIN_ALL);
-    register_clcmd("ncl_test_sandbox_cvars",        "cmd_ncl_test_sandbox_cvars",       ADMIN_ALL);
-    register_clcmd("ncl_test_viewmodelfx_skin",     "cmd_ncl_test_viewmodelfx_skin",    ADMIN_ALL);
-    register_clcmd("ncl_test_viewmodelfx_body",     "cmd_ncl_test_viewmodelfx_body",    ADMIN_ALL);
-    register_clcmd("ncl_test_viewmodelfx_render",   "cmd_ncl_test_viewmodelfx_render",  ADMIN_ALL);
-    register_clcmd("ncl_restore_viewmodelfx",       "cmd_ncl_restore_viewmodelfx",      ADMIN_ALL);
-    register_clcmd("ncl_setfov",                    "cmd_ncl_setfov",                   ADMIN_ALL);
-    register_clcmd("ncl_hudsprite_set",             "cmd_ncl_hudsprite_set",            ADMIN_ALL);
-    register_clcmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL);
+    register_concmd("ncl_is_client_api_ready",       "cmd_ncl_is_client_api_ready",      ADMIN_ALL);
+    register_concmd("ncl_is_using_nextclient",       "cmd_ncl_is_using_nextclient",      ADMIN_ALL);
+    register_concmd("ncl_get_nextclient_version",    "cmd_ncl_get_nextclient_version",   ADMIN_ALL);
+    register_concmd("ncl_get_supported_features",    "cmd_ncl_get_supported_features",   ADMIN_ALL);
+    register_concmd("ncl_test_sandbox_cvars",        "cmd_ncl_test_sandbox_cvars",       ADMIN_ALL);
+    register_concmd("ncl_test_viewmodelfx_skin",     "cmd_ncl_test_viewmodelfx_skin",    ADMIN_ALL);
+    register_concmd("ncl_test_viewmodelfx_body",     "cmd_ncl_test_viewmodelfx_body",    ADMIN_ALL);
+    register_concmd("ncl_test_viewmodelfx_render",   "cmd_ncl_test_viewmodelfx_render",  ADMIN_ALL);
+    register_concmd("ncl_restore_viewmodelfx",       "cmd_ncl_restore_viewmodelfx",      ADMIN_ALL);
+    register_concmd("ncl_setfov",                    "cmd_ncl_setfov",                   ADMIN_ALL);
+    register_concmd("ncl_hudsprite_set",             "cmd_ncl_hudsprite_set",            ADMIN_ALL);
+    register_concmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL);
 
     // Other cmds
     // For ncl_test_sandbox_cvars() if AUTO_RESTORE_CVAR_VALUES is disabled
-    register_clcmd("ncl_restore_cvars_values", "cmd_ncl_restore_cvars_values", ADMIN_ALL);
+    register_concmd("ncl_restore_cvars_values", "cmd_ncl_restore_cvars_values", ADMIN_ALL);
     // For testing HUD limit health
-    register_clcmd("ncl_add_health", "cmd_ncl_add_health", ADMIN_ALL);
+    register_concmd("ncl_add_health", "cmd_ncl_add_health", ADMIN_ALL);
 }
 
 /* <== FORWARDS ==> */
@@ -65,7 +66,16 @@ public ncl_client_api_ready(id) {
 /* <== NATIVES ==> */
 
 public cmd_ncl_is_client_api_ready(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_is_client_api_ready> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_is_client_api_ready> testing called for player: %n", id);
     log_to_file(LOG_FILE, "Result: API ready? %s.", ncl_is_client_api_ready(id)  ? "Yes" : "No");
     return PLUGIN_HANDLED;
 }
@@ -73,7 +83,16 @@ public cmd_ncl_is_client_api_ready(id) {
 /* <=======> */
 
 public cmd_ncl_is_using_nextclient(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_is_using_nextclient> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_is_using_nextclient> testing called for player: %n", id);
 
     new result[32];
     new eNclUsing:is_using_next_client = ncl_is_using_nextclient(id);
@@ -95,7 +114,16 @@ public cmd_ncl_is_using_nextclient(id) {
 /* <=======> */
 
 public cmd_ncl_get_nextclient_version(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_get_nextclient_version> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_get_nextclient_version> testing called for player: %n", id);
 
     new major_version, minor_version, patch_version;
     ncl_get_nextclient_version(id, major_version, minor_version, patch_version);
@@ -107,7 +135,16 @@ public cmd_ncl_get_nextclient_version(id) {
 /* <=======> */
 
 public cmd_ncl_get_supported_features(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_get_supported_features> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_get_supported_features> testing called for player: %n", id);
 
     new eFeaturesFlags:bitsum = ncl_get_supported_features(id);
     new result[256];
@@ -201,7 +238,16 @@ new const CVAR_VALUES[eSandboxCvar][] = {
 };
 
 public cmd_ncl_test_sandbox_cvars(id) {
-    log_to_file(LOG_FILE, "SANDBOX CVAR testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "SANDBOX CVAR testing called for player: %n", id);
 
     ncl_sandbox_cvar_begin(id);
     for (new eSandboxCvar:i; i < eSandboxCvar; i++) {
@@ -253,6 +299,15 @@ public checkCvarValue(id, const cvar[], const value[], const param[]) {
 }
 
 public cmd_ncl_restore_cvars_values(id) {
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
     log_to_file(LOG_FILE, "CVARS from SANDBOX are restored for player: %n", id);
 
     ncl_sandbox_cvar_begin(id);
@@ -270,7 +325,16 @@ new const TEST_SKIN_MODEL[] = "models/v_ak47_with_skins.mdl";
 const SKIN = 1;
 
 public cmd_ncl_test_viewmodelfx_skin(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_write_renderbody> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_write_renderbody> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check a skin changing of view model. If you see not a standart model, the test was successful.");
 
     rg_give_item(id, "weapon_ak47");
@@ -290,7 +354,16 @@ new const TEST_BODY_MODEL[] = "models/v_m4a1_with_body.mdl";
 const BODY = 7;
 
 public cmd_ncl_test_viewmodelfx_body(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_write_renderbody> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_write_renderbody> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check a body changing of view model. If you see not a standart model, the test was successful.");
 
     rg_give_item(id, "weapon_m4a1");
@@ -307,7 +380,16 @@ public cmd_ncl_test_viewmodelfx_body(id) {
 /* <=======> */
 
 public cmd_ncl_test_viewmodelfx_render(id) {
-    log_to_file(LOG_FILE, "NATIVES <ncl_write_renderfx, ncl_write_rendercolor, ncl_write_rendermode, ncl_write_renderamt> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVES <ncl_write_renderfx, ncl_write_rendercolor, ncl_write_rendermode, ncl_write_renderamt> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check the glowing of view model.");
 
     ncl_viewmodelfx_begin(id);
@@ -323,6 +405,15 @@ public cmd_ncl_test_viewmodelfx_render(id) {
 /* <=======> */
 
 public cmd_ncl_restore_viewmodelfx(id) {
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
     log_to_file(LOG_FILE, "All viewmodelfx have been reset for player: %n", id);
 
     ncl_viewmodelfx_begin(id);
@@ -342,7 +433,16 @@ public cmd_ncl_restore_viewmodelfx(id) {
 const Float:FOV_TIME = 2.0;
 
 public cmd_ncl_setfov(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_setfov> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_setfov> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check a FOV changing.");
 
     ncl_setfov(id, 120, FOV_TIME);
@@ -360,7 +460,16 @@ public restore_fov(id) {
 /* <=======> */
 
 public cmd_ncl_hudsprite_set(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_send_hud_sprite> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_send_hud_sprite> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check sprites on screen in game.");
 
     // left-top
@@ -500,7 +609,16 @@ public cmd_ncl_hudsprite_set(id) {
 /* <=======> */
 
 public cmd_ncl_hudsprite_clear(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_clear_hud_sprite> testing called by player: %n", id);
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
+    log_to_file(LOG_FILE, "NATIVE <ncl_clear_hud_sprite> testing called for player: %n", id);
     log_to_file(LOG_FILE, "* You should manually check clearing sprites on screen in game.");
 
     for (new i = 0; i < MAX_HUD_SPRITE_CHANNELS; ++i) {
@@ -663,7 +781,7 @@ public test_ncl_precache_and_replace_custom_sound() {
     
     ncl_precache_sound("test_nextclient/sound_for_all.wav", "test_nextclient/sound_for_nextclient.wav");
 
-    set_task(1.0, "sendSound", .flags = "b");
+    set_task_ex(3.0, "sendSound", .flags = SetTask_Repeat);
 }
 
 public sendSound() {
@@ -681,6 +799,15 @@ public sendSound() {
 /* <== OTHER FUNCS ==> */
 
 public cmd_ncl_add_health(id) {
+    if (id == 0) {
+        id = find_player_ex(FindPlayer_MatchUserId, read_argv_int(1));
+
+        if (id == 0) {
+            log_amx("Player with userid #%i not found.", read_argv_int(1));
+            return;
+        }
+    }
+
     if (!is_user_alive(id)) {
         return;
     }

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -47,7 +47,10 @@ public plugin_init() {
     register_clcmd("ncl_hudsprite_clear",           "cmd_ncl_hudsprite_clear",          ADMIN_ALL);
 
     // Other cmds
+    // For ncl_test_sandbox_cvars() if AUTO_RESTORE_CVAR_VALUES is disabled
     register_clcmd("ncl_restore_cvars_values", "cmd_ncl_restore_cvars_values", ADMIN_ALL);
+    // For testing HUD limit health
+    register_clcmd("ncl_add_health", "cmd_ncl_add_health", ADMIN_ALL);
 }
 
 /* <== FORWARDS ==> */
@@ -674,3 +677,15 @@ public sendSound() {
 }
 
 /* <=== END PRECACHE ===> */
+
+/* <== OTHER FUNCS ==> */
+
+public cmd_ncl_add_health(id) {
+    if (!is_user_alive(id)) {
+        return;
+    }
+
+    set_entvar(id, var_health, 99999999.0);
+}
+
+/* <=== END OTHER FUNCS ===> */

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -24,10 +24,12 @@ new const HUD_SPRITE_KILL[] = "sprites/test_nextclient/hud_sprites/kill.spr"
 new const HUD_SPRITE_BLACK_HOLE[] = "sprites/test_nextclient/hud_sprites/ef_blackhole_loop.spr"
 
 public plugin_init() {
-    register_plugin("Test NCL API", "1.2.0", "Nordic Warrior");
+    register_plugin("Test NCL API", "1.3.0", "Nordic Warrior");
 
-    register_clcmd("ncl_is_next_client",            "cmd_ncl_is_next_client",           ADMIN_ALL);
     register_clcmd("ncl_is_client_api_ready",       "cmd_ncl_is_client_api_ready",      ADMIN_ALL);
+    register_clcmd("ncl_is_using_nextclient",       "cmd_ncl_is_using_nextclient",      ADMIN_ALL);
+    register_clcmd("ncl_get_nextclient_version",    "cmd_ncl_get_nextclient_version",   ADMIN_ALL);
+    register_clcmd("ncl_get_supported_features",    "cmd_ncl_get_supported_features",   ADMIN_ALL);
     register_clcmd("ncl_test_sandbox_cvars",        "cmd_ncl_test_sandbox_cvars",       ADMIN_ALL);
     register_clcmd("ncl_test_viewmodelfx_skin",     "cmd_ncl_test_viewmodelfx_skin",    ADMIN_ALL);
     register_clcmd("ncl_test_viewmodelfx_body",     "cmd_ncl_test_viewmodelfx_body",    ADMIN_ALL);
@@ -51,17 +53,109 @@ public ncl_client_api_ready(id) {
 
 /* <== NATIVES ==> */
 
-public cmd_ncl_is_next_client(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_is_next_client> testing called by player: %n", id);
-    log_to_file(LOG_FILE, "Result: Is player NextClient? %s.", ncl_is_next_client(id) > NCLV_NOT_NEXT_CLIENT ? "Yes" : "No");
+public cmd_ncl_is_client_api_ready(id) {
+    log_to_file(LOG_FILE, "NATIVE <ncl_is_client_api_ready> testing called by player: %n", id);
+    log_to_file(LOG_FILE, "Result: API ready? %s.", ncl_is_client_api_ready(id)  ? "Yes" : "No");
     return PLUGIN_HANDLED;
 }
 
 /* <=======> */
 
-public cmd_ncl_is_client_api_ready(id) {
-    log_to_file(LOG_FILE, "NATIVE <ncl_is_client_api_ready> testing called by player: %n", id);
-    log_to_file(LOG_FILE, "Result: API ready? %s.", ncl_is_client_api_ready(id)  ? "Yes" : "No");
+public cmd_ncl_is_using_nextclient(id) {
+    log_to_file(LOG_FILE, "NATIVE <ncl_is_using_nextclient> testing called by player: %n", id);
+
+    new result[32];
+    new eNclUsing:is_using_next_client = ncl_is_using_nextclient(id);
+
+    if (is_using_next_client == NCL_NOT_USING) { 
+        result = "NCL_NOT_USING";
+    } else if (is_using_next_client == NCL_DECLARE_USING) {
+        result = "NCL_DECLARE_USING";
+    } else if (is_using_next_client == NCL_USING_VERIFICATED) {
+        result = "NCL_USING_VERIFICATED";
+    } else {
+        result = "UNEXPECTED RESULT"
+    }
+
+    log_to_file(LOG_FILE, "Result: Is player using NextClient = %s", result);
+    return PLUGIN_HANDLED;
+}
+
+/* <=======> */
+
+public cmd_ncl_get_nextclient_version(id) {
+    log_to_file(LOG_FILE, "NATIVE <ncl_get_nextclient_version> testing called by player: %n", id);
+
+    new major_version, minor_version, patch_version;
+    ncl_get_nextclient_version(id, major_version, minor_version, patch_version);
+
+    log_to_file(LOG_FILE, "Result: NextClient version = %i.%i.%i", major_version, minor_version, patch_version);
+    return PLUGIN_HANDLED;
+}
+
+/* <=======> */
+
+public cmd_ncl_get_supported_features(id) {
+    log_to_file(LOG_FILE, "NATIVE <ncl_get_supported_features> testing called by player: %n", id);
+
+    new eFeaturesFlags:bitsum = ncl_get_supported_features(id);
+    new result[256];
+
+    if (bitsum & NCL_FEATURE_CVARS_SANDBOX) {
+        add(result, charsmax(result), "NCL_FEATURE_CVARS_SANDBOX");
+        bitsum &= ~NCL_FEATURE_CVARS_SANDBOX;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    if (bitsum & NCL_FEATURE_VIEWMODEL_FX) {
+        add(result, charsmax(result), "NCL_FEATURE_VIEWMODEL_FX");
+        bitsum &= ~NCL_FEATURE_VIEWMODEL_FX;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    if (bitsum & NCL_FEATURE_PRIVATE_PRECACHE) {
+        add(result, charsmax(result), "NCL_FEATURE_PRIVATE_PRECACHE");
+        bitsum &= ~NCL_FEATURE_PRIVATE_PRECACHE;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    if (bitsum & NCL_FEATURE_VERIFICATION) {
+        add(result, charsmax(result), "NCL_FEATURE_VERIFICATION");
+        bitsum &= ~NCL_FEATURE_VERIFICATION;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    if (bitsum & NCL_FEATURE_HUD_SPRITE) {
+        add(result, charsmax(result), "NCL_FEATURE_HUD_SPRITE");
+        bitsum &= ~NCL_FEATURE_HUD_SPRITE;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    if (bitsum & NCL_FEATURE_HUD_SPRITE_RENDERMODE) {
+        add(result, charsmax(result), "NCL_FEATURE_HUD_SPRITE_RENDERMODE");
+        bitsum &= ~NCL_FEATURE_HUD_SPRITE_RENDERMODE;
+
+        if (bitsum > 0) {
+            add(result, charsmax(result), " | ");
+        }
+    }
+
+    log_to_file(LOG_FILE, "Result: %s", result);
     return PLUGIN_HANDLED;
 }
 
@@ -99,12 +193,12 @@ public cmd_ncl_test_sandbox_cvars(id) {
     log_to_file(LOG_FILE, "SANDBOX CVAR testing called by player: %n", id);
 
     ncl_sandbox_cvar_begin(id);
-    for(new eSandboxCvar:i; i < eSandboxCvar; i++) {
+    for (new eSandboxCvar:i; i < eSandboxCvar; i++) {
         ncl_write_sandbox_cvar(i, CVAR_VALUES[any:i]);
     }
     ncl_sandbox_cvar_end();
 
-    for(new eSandboxCvar:i; i < eSandboxCvar; i++) {
+    for (new eSandboxCvar:i; i < eSandboxCvar; i++) {
         query_client_cvar(id, CVAR_STRING[i], "checkCvarValue");
     }
 
@@ -115,11 +209,11 @@ public checkCvarValue(id, const cvar[], const value[], const param[]) {
     static any:successfulTest;
     static any:testsPassed;
 
-    for(new eSandboxCvar:i; i < eSandboxCvar; i++) {
-        if(strcmp(cvar, CVAR_STRING[i]) == 0) {
+    for (new eSandboxCvar:i; i < eSandboxCvar; i++) {
+        if (strcmp(cvar, CVAR_STRING[i]) == 0) {
             log_to_file(LOG_FILE, "CVAR <%s> EXPECTED VALUE: %s ACTUAL VALUE: %s.", cvar, CVAR_VALUES[i], value);
 
-            if(strcmp(value, CVAR_VALUES[i]) == 0) {
+            if (strcmp(value, CVAR_VALUES[i]) == 0) {
                 successfulTest++;
             }
         }
@@ -127,7 +221,7 @@ public checkCvarValue(id, const cvar[], const value[], const param[]) {
 
     testsPassed++;
 
-    if(successfulTest == eSandboxCvar && testsPassed == eSandboxCvar) {
+    if (successfulTest == eSandboxCvar && testsPassed == eSandboxCvar) {
         log_to_file(LOG_FILE, "<SANDBOX CVAR testing was SUCCESSFUL>", id);
         successfulTest = 0;
         testsPassed = 0;
@@ -136,7 +230,7 @@ public checkCvarValue(id, const cvar[], const value[], const param[]) {
         cmd_ncl_restore_cvars_values(id);
         #endif
     }
-    else if(successfulTest != eSandboxCvar && testsPassed == eSandboxCvar) {
+    else if (successfulTest != eSandboxCvar && testsPassed == eSandboxCvar) {
         log_to_file(LOG_FILE, "[!] SANDBOX CVAR testing FAILED [!]", id);
         successfulTest = 0;
         testsPassed = 0;
@@ -151,7 +245,7 @@ public cmd_ncl_restore_cvars_values(id) {
     log_to_file(LOG_FILE, "CVARS from SANDBOX are restored for player: %n", id);
 
     ncl_sandbox_cvar_begin(id);
-    for(new eSandboxCvar:i; i < eSandboxCvar; i++) {
+    for (new eSandboxCvar:i; i < eSandboxCvar; i++) {
         ncl_write_sandbox_cvar(i, "");
     }
     ncl_sandbox_cvar_end();
@@ -233,6 +327,7 @@ public cmd_ncl_restore_viewmodelfx(id) {
 }
 
 /* <=======> */
+
 const Float:FOV_TIME = 2.0;
 
 public cmd_ncl_setfov(id) {
@@ -240,10 +335,18 @@ public cmd_ncl_setfov(id) {
     log_to_file(LOG_FILE, "* You should manually check a FOV changing.");
 
     ncl_setfov(id, 120, FOV_TIME);
-    set_task(FOV_TIME, "restoreFOV", id);
+    set_task(FOV_TIME, "restore_fov", id);
 
     return PLUGIN_HANDLED;
 }
+
+public restore_fov(id) {
+    log_to_file(LOG_FILE, "FOV automatically restored to 90 for player: %n", id);
+
+    ncl_setfov(id, 90, FOV_TIME);
+}
+
+/* <=======> */
 
 public cmd_ncl_hudsprite_set(id) {
     log_to_file(LOG_FILE, "NATIVE <ncl_send_hud_sprite> testing called by player: %n", id);
@@ -382,6 +485,8 @@ public cmd_ncl_hudsprite_set(id) {
     return PLUGIN_HANDLED;
 }
 
+/* <=======> */
+
 public cmd_ncl_hudsprite_clear(id) {
     log_to_file(LOG_FILE, "NATIVE <ncl_clear_hud_sprite> testing called by player: %n", id);
 
@@ -390,12 +495,6 @@ public cmd_ncl_hudsprite_clear(id) {
     }
 
     return PLUGIN_HANDLED;
-}
-
-public restoreFOV(id) {
-    log_to_file(LOG_FILE, "FOV automatically restored to 90 for player: %n", id);
-
-    ncl_setfov(id, 90, FOV_TIME);
 }
 
 /* <=== END NATIVES ===> */
@@ -475,8 +574,8 @@ public test_ncl_precache_client_only() {
     ncl_precache_client_only("sprites/radar640.spr",        "sprites/test_nextclient/radar640.spr"          ); 
     ncl_precache_client_only("sprites/radaropaque640.spr",  "sprites/test_nextclient/radaropaque640.spr"    );
 
-    for(new WeaponIdType:weaponID = WEAPON_P228; weaponID <= WEAPON_P90; weaponID++) {
-        if(weaponID == WEAPON_GLOCK) {
+    for (new WeaponIdType:weaponID = WEAPON_P228; weaponID <= WEAPON_P90; weaponID++) {
+        if (weaponID == WEAPON_GLOCK) {
             continue;
         }
 
@@ -504,7 +603,7 @@ public test_ncl_precache_and_replace_custom_model() {
 }
 
 public RG_CBasePlayer_Spawn_post(id) {
-    if(!is_user_alive(id)) {
+    if (!is_user_alive(id)) {
         return;
     }
 
@@ -555,8 +654,8 @@ public test_ncl_precache_and_replace_custom_sound() {
 }
 
 public sendSound() {
-    for(new player = 1; player <= MaxClients; player++) {
-        if(!is_user_connected(player)) {
+    for (new player = 1; player <= MaxClients; player++) {
+        if (!is_user_connected(player)) {
             continue;
         }
 

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -7,6 +7,10 @@
 
 new LOG_FILE[] = "test_nextclient_api.log";
 
+// Automated testing of natives where no human visual control is needed
+// It is done in the ncl_client_api_ready() forward.
+// #define AUTOTESTS
+
 // Uncomment this if you do not want to check the values of the sandbox CVars yourself
 #define AUTO_RESTORE_CVAR_VALUES
 
@@ -58,6 +62,11 @@ public plugin_init() {
 
 public ncl_client_api_ready(id) {
     log_to_file(LOG_FILE, "FORWARD <ncl_client_api_ready> called for player: %n", id);
+
+    #if defined AUTOTESTS
+    start_autotests(id);
+    #endif
+
     return PLUGIN_HANDLED;
 }
 
@@ -107,7 +116,7 @@ public cmd_ncl_is_using_nextclient(id) {
         result = "UNEXPECTED RESULT"
     }
 
-    log_to_file(LOG_FILE, "Result: Is player using NextClient = %s", result);
+    log_to_file(LOG_FILE, "Result: %s", result);
     return PLUGIN_HANDLED;
 }
 
@@ -796,7 +805,7 @@ public sendSound() {
 
 /* <=== END PRECACHE ===> */
 
-/* <== OTHER FUNCS ==> */
+/* <== OTHER TEST FUNCS ==> */
 
 public cmd_ncl_add_health(id) {
     if (id == 0) {
@@ -814,6 +823,16 @@ public cmd_ncl_add_health(id) {
 
     set_entvar(id, var_health, 99999999.0);
     return PLUGIN_HANDLED;
+}
+
+/* <=======> */
+
+public start_autotests(id) {
+    cmd_ncl_is_client_api_ready(id);
+    cmd_ncl_is_using_nextclient(id);
+    cmd_ncl_get_nextclient_version(id);
+    cmd_ncl_get_supported_features(id);
+    cmd_ncl_test_sandbox_cvars(id);
 }
 
 /* <=== END OTHER FUNCS ===> */

--- a/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
+++ b/amxx_test/addons/amxmodx/scripting/test_nextclient_api.sma
@@ -353,6 +353,7 @@ public restore_fov(id) {
 
 public cmd_ncl_hudsprite_set(id) {
     log_to_file(LOG_FILE, "NATIVE <ncl_send_hud_sprite> testing called by player: %n", id);
+    log_to_file(LOG_FILE, "* You should manually check sprites on screen in game.");
 
     // left-top
     ncl_send_hud_sprite(
@@ -364,7 +365,7 @@ public cmd_ncl_hudsprite_set(id) {
         .frame = _,
         .frameRate = _,
         .inTime = _,
-        .holdTime = 2.0,
+        .holdTime = 5.0,
         .outTime = 1.0,
         .x = 0.0,
         .y = 0.0,
@@ -383,7 +384,7 @@ public cmd_ncl_hudsprite_set(id) {
         .frame = _,
         .frameRate = _,
         .inTime = 3.0,
-        .holdTime = 3.0,
+        .holdTime = 6.0,
         .outTime = 3.0,
         .x = 0.0,
         .y = -1.0,
@@ -492,6 +493,7 @@ public cmd_ncl_hudsprite_set(id) {
 
 public cmd_ncl_hudsprite_clear(id) {
     log_to_file(LOG_FILE, "NATIVE <ncl_clear_hud_sprite> testing called by player: %n", id);
+    log_to_file(LOG_FILE, "* You should manually check clearing sprites on screen in game.");
 
     for (new i = 0; i < MAX_HUD_SPRITE_CHANNELS; ++i) {
        ncl_clear_hud_sprite(id, i);
@@ -508,8 +510,8 @@ public plugin_precache() {
     precache_model(TEST_SKIN_MODEL);
     precache_model(TEST_BODY_MODEL);
 
-    precache_model(HUD_SPRITE_KILL)
-    precache_model(HUD_SPRITE_BLACK_HOLE)
+    precache_model(HUD_SPRITE_KILL);
+    precache_model(HUD_SPRITE_BLACK_HOLE);
 
 #if defined TEST_PRECACHE_AND_REPLACE_DEFAULT_MODELS
     test_ncl_precache_and_replace_default_model();

--- a/src/api/NextClientApi.cpp
+++ b/src/api/NextClientApi.cpp
@@ -155,11 +155,7 @@ void NextClientApi::OnPlayerPostThink(int client)
         return;
 
     auto data = &players_[client];
-    if (!data->is_api_ready && (
-            data->deprecated_client_version != NextClientVersion::NOT_NEXTCLIENT
-            || data->client_version
-        )
-    ) {
+    if (!data->is_api_ready && data->is_using_nextclient) {
         data->is_api_ready = true;
 
         MF_ExecuteForward(forward_api_ready_, client);


### PR DESCRIPTION
- Added the ability to test new natives: `ncl_is_using_nextclient(), ncl_get_nextclient_version(), ncl_get_supported_features()`
- Added the capability to test the visual HUD health limit.
- Implemented automated tests for natives that do not require human visual control. If the function is enabled, tests are initiated using the `ncl_client_api_ready()` forward.
- Introduced the option to test natives in the server console by userid.
- Numerous comments have been added.